### PR TITLE
Fix: logspam due to missing VINTF manifest for livedisplay/sensorcalibrate hal

### DIFF
--- a/hidl/manifest_lahaina.xml
+++ b/hidl/manifest_lahaina.xml
@@ -554,4 +554,26 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <instance>MwqemAdapter</instance>
         </interface>
     </hal>
+    <hal format="hidl">
+        <name>vendor.qti.hardware.sensorscalibrate</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>ISensorsCalibrate</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>vendor.lineage.livedisplay</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IDisplayModes</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IPictureAdjustment</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
 </manifest>


### PR DESCRIPTION
This potentially fixes missing manifests error prompts causing logspam in vili

```
04-15 10:30:04.258   622   622 I hwservicemanager: getTransport: Cannot find entry vendor.qti.hardware.sensorscalibrate@1.0::ISensorsCalibrate/default in either framework or device VINTF manifest.
04-15 10:30:04.266   622   622 I hwservicemanager: getTransport: Cannot find entry vendor.qti.hardware.sensorscalibrate@1.0::ISensorsCalibrate/default in either framework or device VINTF manifest.
04-15 10:30:04.266  6681  6681 E HidlServiceManagement: Service vendor.qti.hardware.sensorscalibrate@1.0::ISensorsCalibrate/default must be in VINTF manifest in order to register/get.
04-15 10:30:04.266  6681  6681 E LegacySupport: Could not register service vendor.qti.hardware.sensorscalibrate@1.0::ISensorsCalibrate/default (-2147483648).
```

```
04-15 10:29:59.880  6676  6676 I vendor.lineage.livedisplay@2.0-service-sdm: LiveDisplay HAL service is starting.
04-15 10:29:59.888   622   622 I hwservicemanager: getTransport: Cannot find entry vendor.lineage.livedisplay@2.0::IPictureAdjustment/default in either framework or device VINTF manifest.
04-15 10:29:59.889  6676  6676 E HidlServiceManagement: Service vendor.lineage.livedisplay@2.0::IPictureAdjustment/default must be in VINTF manifest in order to register/get.
04-15 10:29:59.889  6676  6676 E vendor.lineage.livedisplay@2.0-service-sdm: Could not register service for LiveDisplay HAL PictureAdjustment Iface (-2147483648)
04-15 10:29:59.890  6676  6676 E vendor.lineage.livedisplay@2.0-service-sdm: Could not register service for LiveDisplay HAL
04-15 10:29:59.890  6676  6676 E vendor.lineage.livedisplay@2.0-service-sdm: LiveDisplay HAL service is shutting down.
```